### PR TITLE
fix-windows-only-directory-separator

### DIFF
--- a/helpers/helpers.php
+++ b/helpers/helpers.php
@@ -1,10 +1,10 @@
 <?php
-require_once __DIR__.'\..\config\app.php';
+require_once __DIR__.'/../config/app.php';
 
 if(!function_exists('view')){
     function view($view = null, $data = []) {
         global $app_config;
         extract($data);
-        require_once __DIR__.'\..\views\\'.strtolower($view).'.php';
+        require_once __DIR__.'/../views/'.strtolower($view).'.php';
     }
 }


### PR DESCRIPTION
In helpers/helpers.php there were some backslashes used as directory separators,
making throw errors on linux (and mac i suppose)